### PR TITLE
Support for Laravel Octane

### DIFF
--- a/src/ZoapController.php
+++ b/src/ZoapController.php
@@ -125,7 +125,7 @@ class ZoapController
                 $output->headers->set($key, $value);
             }
             
-            if (isset($_GET['wsdl'])) {
+            if (request()->exists('wsdl')) {
 
                 // Create wsdl object and register type(s).
                 $wsdl = new Wsdl('wsdl', $this->endpoint);
@@ -159,7 +159,7 @@ class ZoapController
 
                 // Intercept response, then decide what to do with it.
                 $server->setReturnResponse(true);
-                $response = $server->handle();
+                $response = $server->handle(request()->getContent());
 
                 // Deal with a thrown exception that was converted into a SoapFault.
                 // SoapFault thrown directly in a service class bypasses this code.


### PR DESCRIPTION
The following changes provide better integration with the framework and allow the use of Laravel Octane (swoole), which don't initialize global variables in the same way as php-fpm.